### PR TITLE
Adding PIP to the list of conda packages

### DIFF
--- a/Challenge02/Challenge 2.ipynb
+++ b/Challenge02/Challenge 2.ipynb
@@ -217,7 +217,7 @@
     "\n",
     "See [this tutorial](https://github.com/MicrosoftDocs/mslearn-aml-labs/blob/master/02-Training_Models.ipynb) for a starting point\n",
     "\n",
-    "Use the scikit-learn and lightgbm conda packages"
+    "Use the pip, scikit-learn and lightgbm conda packages"
    ]
   },
   {


### PR DESCRIPTION
PIP is no longer implicitly included and is therefore required to be explicitly added to the conda packages.  If not done, the experiment goes into an infinite error loop, so recommend adding this tip to prevent students from getting too frustrated.